### PR TITLE
Windows Testing Update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,9 @@ Scaffold out methods and tests for collaborative data cleaning.
 Usage:
 ======
 
-This works on Linux with Python 2.7, 3.3, 3.4 and 3.5, and on OSX with Python 2.7 and 3.5 (and probably 3.3 and 3.4, but that hasn't been tested. It may work on Windows (but probably not).
+This works on Linux with Python 2.7, 3.3, 3.4 and 3.5, and on OSX with Python 2.7 and 3.5 (and probably 3.3 and 3.4, but that hasn't been tested.  
+It works on Windows (tested using Python 3.5.2 :: Anaconda 4.1.1 (64-bit)). 
+Integration with Trello on Windows using tddc is yet to be tested though.
 
 Install the package with:
 ``$ pip install tddc``


### PR DESCRIPTION
Added the following info:
It works on Windows (tested using Python 3.5.2 :: Anaconda 4.1.1 (64-bit)). 
Integration with Trello on Windows using tddc is yet to be tested though.
