### PR TITLE
Updated list of suppported platforms

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ Usage:
 ======
 
 This works on Linux with Python 2.7, 3.3, 3.4 and 3.5, and on OSX with Python 2.7 and 3.5 (and probably 3.3 and 3.4, but those haven't been tested).
-It works on Windows 10 (tested using Python 3.5.2 :: Anaconda 4.1.1 (64-bit)).
-It works on Andriod Version 5.0.1 via GNURoot Debian (tested using Python 2.7.9)
+It also works on Windows 10 (tested using Python 3.5.2 :: Anaconda 4.1.1 (64-bit)),
+and Android Version 5.0.1 via GNURoot Debian (tested using Python 2.7.9).
 
 Install the package with:
 

--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,8 @@ Usage:
 ======
 
 This works on Linux with Python 2.7, 3.3, 3.4 and 3.5, and on OSX with Python 2.7 and 3.5 (and probably 3.3 and 3.4, but those haven't been tested).
-It works on Windows (tested using Python 3.5.2 :: Anaconda 4.1.1 (64-bit)).
-Integration with Trello on Windows using tddc is yet to be tested though.
+It works on Windows 10 (tested using Python 3.5.2 :: Anaconda 4.1.1 (64-bit)).
+It works on Andriod Version 5.0.1 via GNURoot Debian (tested using Python 2.7.9)
 
 Install the package with:
 


### PR DESCRIPTION
Trello Integration now works on both Android and Windows Platforms.
